### PR TITLE
Add Programmable Messaging endpoints

### DIFF
--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -69,6 +69,8 @@ defmodule ExTwilio.Config do
 
   def video_url, do: "https://video.twilio.com/v1"
 
+  def programmable_messaging_url, do: "https://messaging.twilio.com/v1"
+
   @doc """
   A light wrapper around `Application.get_env/2`, providing automatic support for
   `{:system, "VAR"}` tuples.

--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -71,6 +71,8 @@ defmodule ExTwilio.Config do
 
   def programmable_messaging_url, do: "https://messaging.twilio.com/v1"
 
+  def trust_hub_url, do: "https://trusthub.twilio.com/v1/"
+
   @doc """
   A light wrapper around `Application.get_env/2`, providing automatic support for
   `{:system, "VAR"}` tuples.

--- a/lib/ex_twilio/resources/programmable_messaging/a2p_campaign.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/a2p_campaign.ex
@@ -1,4 +1,9 @@
 defmodule ExTwilio.ProgrammableMessaging.A2PCampaign do
+  @moduledoc """
+  Represents an US A2P Campaign resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/us-a2p-campaign-resource)
+  """
     defstruct sid: nil,
         account_sid: nil,
         brand_registration_sid: nil,

--- a/lib/ex_twilio/resources/programmable_messaging/a2p_campaign.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/a2p_campaign.ex
@@ -1,0 +1,35 @@
+defmodule ExTwilio.ProgrammableMessaging.A2PCampaign do
+    defstruct sid: nil,
+        account_sid: nil,
+        brand_registration_sid: nil,
+        messaging_service_sid: nil,
+        description: nil,
+        message_samples: nil,
+        us_app_to_person_usecase: nil,
+        has_embedded_links: nil,
+        has_embedded_phone: nil,
+        campaign_status: nil,
+        campaign_id: nil,
+        is_externally_registered: nil,
+        rate_limits: nil,
+        date_created: nil,
+        date_updated: nil,
+        url: nil,
+        mock: false
+
+    use ExTwilio.Resource,
+        import: [
+          :stream,
+          :all,
+          :find,
+          :create,
+          :destroy
+        ]
+
+    def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+
+    def resource_name, do: "Compliance/Usa2p"
+end

--- a/lib/ex_twilio/resources/programmable_messaging/alpha_sender.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/alpha_sender.ex
@@ -1,0 +1,29 @@
+defmodule ExTwilio.ProgrammableMessaging.AlphaSender do
+  @moduledoc """
+  Represents an AlphaSender resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/alphasender-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            alpha_sender: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/phone_number.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/phone_number.ex
@@ -1,0 +1,30 @@
+defmodule ExTwilio.ProgrammableMessaging.PhoneNumber do
+  @moduledoc """
+  Represents a PhoneNumber resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/phonenumber-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            phone_number: nil,
+            country_code: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/service.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/service.ex
@@ -1,0 +1,38 @@
+defmodule ExTwilio.ProgrammableMessaging.Service do
+  @moduledoc """
+  Represents a Service resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            friendly_name: nil,
+            date_created: nil,
+            date_updated: nil,
+            inbound_request_url: nil,
+            inbound_method: nil,
+            fallback_url: nil,
+            fallback_method: nil,
+            status_callback: nil,
+            sticky_sender: nil,
+            mms_converter: nil,
+            smart_encoding: nil,
+            scan_message_content: nil,
+            fallback_to_long_code: nil,
+            area_code_geomatch: nil,
+            synchronous_validation: nil,
+            validity_period: nil,
+            url: nil,
+            links: nil,
+            use_inbound_webhook_on_number: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :update,
+      :destroy
+    ]
+end

--- a/lib/ex_twilio/resources/programmable_messaging/short_code.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/short_code.ex
@@ -1,0 +1,30 @@
+defmodule ExTwilio.ProgrammableMessaging.ShortCode do
+  @moduledoc """
+  Represents a ShortCode resource in the Twilio Programmable Messaging API.
+
+  - [Twilio docs](https://www.twilio.com/docs/messaging/services/api/shortcode-resource)
+  """
+  defstruct sid: nil,
+            account_sid: nil,
+            service_sid: nil,
+            date_created: nil,
+            date_updated: nil,
+            short_code: nil,
+            country_code: nil,
+            capabilities: nil,
+            url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents,
+    do: [
+      %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.Service, key: :service}
+    ]
+end

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -68,6 +68,10 @@ defmodule ExTwilio.UrlGenerator do
           url = add_segments(Config.video_url(), module, id, options)
           {url, options}
 
+        ["ExTwilio", "ProgrammableMessaging" | _] ->
+          url = add_segments(Config.programmable_messaging_url(), module, id, options)
+          {url, options}
+
         _ ->
           # Add Account SID segment if not already present
           options = add_account_to_options(module, options)

--- a/lib/ex_twilio/url_generator.ex
+++ b/lib/ex_twilio/url_generator.ex
@@ -72,6 +72,10 @@ defmodule ExTwilio.UrlGenerator do
           url = add_segments(Config.programmable_messaging_url(), module, id, options)
           {url, options}
 
+        ["ExTwilio", "TrustHub" | _ ] ->
+          url = add_segments(Config.trust_hub_url(), module, id, options)
+          {url, options}
+
         _ ->
           # Add Account SID segment if not already present
           options = add_account_to_options(module, options)
@@ -133,7 +137,7 @@ defmodule ExTwilio.UrlGenerator do
   @spec resource_name(atom | String.t()) :: String.t()
   def resource_name(module) do
     name = to_string(module)
-    [[name]] = Regex.scan(~r/[a-z]+$/i, name)
+    [[name]] = Regex.scan(~r/[a-z0-9]+$/i, name)
     Inflex.pluralize(name)
   end
 


### PR DESCRIPTION
Addresses [#684](https://github.com/InFieldPro/infield_pro/issues/684). This includes New Aperio's changes on this [branch](https://github.com/newaperio/ex_twilio/tree/add-programmable-messaging) and the A2P [resource](https://www.twilio.com/docs/messaging/services/api/us-a2p-campaign-resource) that was missing from it, which we'll need in step 4 [here](https://www.twilio.com/docs/sms/a2p-10dlc/onboarding-isv-api#4-create-messaging-service).
The `UrlGenerator.build_url/3` function takes a module name and matches it to a known resource in the Twilio API and formats it as the API expects (mostly pluralizing). The second argument gives us the `id` (usually) of the resource, like:
```
> ExTwilio.UrlGenerator.build_url(ExTwilio.ProgrammableMessaging.Service, "1234")
"https://messaging.twilio.com/v1/Services/1234"
```
The module can also expose a `parents/0` function which tells the URL generator which paths to inject upstream of the resource. For example, 
```
> ExTwilio.UrlGenerator.build_url(ExTwilio.ProgrammableMessaging.PhoneNumber, "1234", service: "XXXX")
"https://messaging.twilio.com/v1/Services/XXXX/PhoneNumbers/1234"
```
The `resource_name/0` function just overrides the module name when constructing the path. 
Added some TrustHub config in preparation for the next PR. 