### PR TITLE
add TrustHub API resources configuration and Brand Registration

### DIFF
--- a/lib/ex_twilio/config.ex
+++ b/lib/ex_twilio/config.ex
@@ -71,7 +71,7 @@ defmodule ExTwilio.Config do
 
   def programmable_messaging_url, do: "https://messaging.twilio.com/v1"
 
-  def trust_hub_url, do: "https://trusthub.twilio.com/v1/"
+  def trust_hub_url, do: "https://trusthub.twilio.com/v1"
 
   @doc """
   A light wrapper around `Application.get_env/2`, providing automatic support for

--- a/lib/ex_twilio/resources/programmable_messaging/brand_registration.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/brand_registration.ex
@@ -1,0 +1,33 @@
+defmodule ExTwilio.ProgrammableMessaging.BrandRegistration do
+  defstruct sid: nil,
+    account_sid: nil,
+    customer_profile_bundle_sid: nil,
+    a2p_profile_bundle_sid: nil,
+    date_created: nil,
+    date_updated: nil,
+    brand_type: nil,
+    status: nil,
+    tcr_id: nil,
+    failure_reason: nil,
+    url: nil,
+    brand_score: nil,
+    brand_feedback: nil,
+    identity_status: nil,
+    russell_3000: nil,
+    government_entity: nil,
+    tax_exempt_status: nil,
+    skip_automatic_sec_vet: nil,
+    mock: nil,
+    links: nil
+
+  use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :update
+      ]
+
+  def resource_name, do: "a2p/BrandRegistrations"
+end

--- a/lib/ex_twilio/resources/programmable_messaging/vetting.ex
+++ b/lib/ex_twilio/resources/programmable_messaging/vetting.ex
@@ -1,0 +1,19 @@
+defmodule ExTwilio.ProgrammableMessaging.Vetting do
+  defstruct brand_sid: nil,
+    vetting_provider: nil,
+    vetting_id: nil
+
+  use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :update
+      ]
+
+  def parents,
+  do: [
+    %ExTwilio.Parent{module: ExTwilio.ProgrammableMessaging.BrandRegistration, key: :brand_sid}
+  ]
+end

--- a/lib/ex_twilio/resources/trust_hub/channel_endpoint_assignment.ex
+++ b/lib/ex_twilio/resources/trust_hub/channel_endpoint_assignment.ex
@@ -1,0 +1,23 @@
+defmodule ExTwilio.TrustHub.ChannelEndpointAssignment do
+  defstruct sid: nil,
+    customer_profile_sid: nil,
+    account_sid: nil,
+    channel_endpoint_sid: nil,
+    channel_endpoint_type: nil,
+    date_created: nil,
+    url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TrustHub.CustomerProfile, key: :customer_profile_sid},
+    %ExTwilio.Parent{module: ExTwilio.TrustHub.TrustProducts, key: :trust_product_sid}
+  ]
+end

--- a/lib/ex_twilio/resources/trust_hub/customer_profile.ex
+++ b/lib/ex_twilio/resources/trust_hub/customer_profile.ex
@@ -1,0 +1,23 @@
+defmodule ExTwilio.TrustHub.CustomerProfile do
+    defstruct sid: nil,
+        account_sid: nil,
+        policy_sid: nil,
+        friendly_name: nil,
+        status: nil,
+        email: nil,
+        status_callback: nil,
+        valid_until: nil,
+        date_created: nil,
+        date_updated: nil,
+        url: nil,
+        links: nil
+
+    use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :destroy
+      ]
+end

--- a/lib/ex_twilio/resources/trust_hub/end_user.ex
+++ b/lib/ex_twilio/resources/trust_hub/end_user.ex
@@ -1,0 +1,18 @@
+defmodule ExTwilio.TrustHub.EndUser do
+  defstruct sid: nil,
+  friendly_name: nil,
+  account_sid: nil,
+  url: nil,
+  date_created: nil,
+  date_updated: nil,
+  attributes: nil
+
+    use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :destroy
+      ]
+end

--- a/lib/ex_twilio/resources/trust_hub/end_user_type.ex
+++ b/lib/ex_twilio/resources/trust_hub/end_user_type.ex
@@ -1,0 +1,14 @@
+defmodule ExTwilio.TrustHub.EndUserType do
+  defstruct sid: nil,
+    friendly_name: nil,
+    machine_name: nil,
+    url: nil,
+    fields: nil
+
+    use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find
+      ]
+end

--- a/lib/ex_twilio/resources/trust_hub/entity_assignment.ex
+++ b/lib/ex_twilio/resources/trust_hub/entity_assignment.ex
@@ -1,0 +1,22 @@
+defmodule ExTwilio.TrustHub.EntityAssignment do
+  defstruct sid: nil,
+    customer_profile_sid: nil,
+    account_sid: nil,
+    object_sid: nil,
+    date_created: nil,
+    url: nil
+
+    use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :destroy
+      ]
+
+    def parents, do: [
+      %ExTwilio.Parent{module: ExTwilio.TrustHub.CustomerProfile, key: :customer_profile_sid},
+      %ExTwilio.Parent{module: ExTwilio.TrustHub.TrustProduct, key: :trust_product_sid}
+    ]
+end

--- a/lib/ex_twilio/resources/trust_hub/evalution.ex
+++ b/lib/ex_twilio/resources/trust_hub/evalution.ex
@@ -1,0 +1,22 @@
+defmodule ExTwilio.TrustHub.Evaluation do
+  defstruct sid: nil,
+    account_sid: nil,
+    policy_sid: nil,
+    customer_profile_sid: nil,
+    status: nil,
+    date_created: nil,
+    url: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create
+    ]
+
+  def parents, do: [
+    %ExTwilio.Parent{module: ExTwilio.TrustHub.CustomerProfile, key: :customer_profile_sid},
+    %ExTwilio.Parent{module: ExTwilio.TrustHub.TrustProduct, key: :trust_product_sid}
+  ]
+end

--- a/lib/ex_twilio/resources/trust_hub/policy.ex
+++ b/lib/ex_twilio/resources/trust_hub/policy.ex
@@ -1,0 +1,14 @@
+defmodule ExTwilio.TrustHub.Policy do
+  defstruct sid: nil,
+    friendly_name: nil,
+    url: nil,
+    requirements: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create
+    ]
+end

--- a/lib/ex_twilio/resources/trust_hub/supporting_document.ex
+++ b/lib/ex_twilio/resources/trust_hub/supporting_document.ex
@@ -1,0 +1,19 @@
+defmodule ExTwilio.TrustHub.SupportingDocument do
+  defstruct sid: nil,
+    account_sid: nil,
+    status: nil,
+    date_updated: nil,
+    friendly_name: nil,
+    url: nil,
+    date_created: nil,
+    attributes: nil,
+    type: nil,
+    mime_type: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find
+    ]
+end

--- a/lib/ex_twilio/resources/trust_hub/supporting_document_type.ex
+++ b/lib/ex_twilio/resources/trust_hub/supporting_document_type.ex
@@ -1,0 +1,16 @@
+defmodule ExTwilio.TrustHub.SupportingDocumentType do
+  defstruct sid: nil,
+    friendly_name: nil,
+    machine_name: nil,
+    url: nil,
+    fields: nil
+
+  use ExTwilio.Resource,
+    import: [
+      :stream,
+      :all,
+      :find,
+      :create,
+      :destroy
+    ]
+end

--- a/lib/ex_twilio/resources/trust_hub/trust_product.ex
+++ b/lib/ex_twilio/resources/trust_hub/trust_product.ex
@@ -1,0 +1,23 @@
+defmodule ExTwilio.TrustHub.TrustProduct do
+  defstruct sid: nil,
+    account_sid: nil,
+    policy_sid: nil,
+    friendly_name: nil,
+    status: nil,
+    email: nil,
+    status_callback: nil,
+    valid_until: nil,
+    date_created: nil,
+    date_updated: nil,
+    url: nil,
+    links: nil
+
+    use ExTwilio.Resource,
+      import: [
+        :stream,
+        :all,
+        :find,
+        :create,
+        :destroy
+      ]
+end


### PR DESCRIPTION
Addresses [#685](https://github.com/InFieldPro/infield_pro/issues/685).
requires PR #1 to be merged first.
Same deal as #1 but for TrustHub endpoints specifically, as well as the Brand Registration endpoint which handles registering a Campaign Verify token to an existing brand. 
Some of the schemas may change but the URL structure should be correct.
