### PR TITLE
Update SupportingDocument resources

### DIFF
--- a/lib/ex_twilio/resources/trust_hub/supporting_document.ex
+++ b/lib/ex_twilio/resources/trust_hub/supporting_document.ex
@@ -14,6 +14,9 @@ defmodule ExTwilio.TrustHub.SupportingDocument do
     import: [
       :stream,
       :all,
-      :find
+      :find,
+      :create,
+      :destroy,
+      :update
     ]
 end

--- a/lib/ex_twilio/resources/trust_hub/supporting_document_type.ex
+++ b/lib/ex_twilio/resources/trust_hub/supporting_document_type.ex
@@ -9,8 +9,6 @@ defmodule ExTwilio.TrustHub.SupportingDocumentType do
     import: [
       :stream,
       :all,
-      :find,
-      :create,
-      :destroy
+      :find
     ]
 end


### PR DESCRIPTION
The wrong methods were assigned to the two SupportingDocument and SupportingDocumentType resources. This fixes that mistake. 