### PR TITLE
update hmac signer algorithm and joken version. 

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -32,7 +32,7 @@ defmodule ExTwilio.RequestValidator do
     |> Enum.join()
   end
 
-  defp compute_hmac(data, key), do: hmac(:sha, key, data)
+  defp compute_hmac(data, key), do: hmac(:sha256, key, data)
 
   # TODO: remove when we require OTP 22
   if System.otp_release() >= "22" do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExTwilio.Mixfile do
       {:httpoison, ">= 0.9.0"},
       {:jason, "~> 1.2"},
       {:inflex, "~> 2.0"},
-      {:joken, "~> 2.0"},
+      {:joken, ">= 2.3.0"},
       {:dialyze, "~> 0.2.0", only: [:dev, :test]},
       {:mock, "~> 0.3", only: :test},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},


### PR DESCRIPTION
Unclear why this signer error didn't come up before. It's clearly incorrect and should have been failling tests this whole time. See erlang mac [docs](https://www.erlang.org/doc/man/crypto.html#mac-4)
Updating the Joken version shouldn't change anything in this case.
It started breaking on these [tests](https://github.com/InFieldPro/infield_pro/runs/8019210945?check_suite_focus=true).  