### PR TITLE
Revert "update hmac signer algorithm and joken version. "

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -32,7 +32,7 @@ defmodule ExTwilio.RequestValidator do
     |> Enum.join()
   end
 
-  defp compute_hmac(data, key), do: hmac(:sha256, key, data)
+  defp compute_hmac(data, key), do: hmac(:sha, key, data)
 
   # TODO: remove when we require OTP 22
   if System.otp_release() >= "22" do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExTwilio.Mixfile do
       {:httpoison, ">= 0.9.0"},
       {:jason, "~> 1.2"},
       {:inflex, "~> 2.0"},
-      {:joken, ">= 2.3.0"},
+      {:joken, "~> 2.0"},
       {:dialyze, "~> 0.2.0", only: [:dev, :test]},
       {:mock, "~> 0.3", only: :test},
       {:ex_doc, ">= 0.0.0", only: [:dev, :test]},


### PR DESCRIPTION
This reverts commit 32a5b5650068588b71ecb2925f2651dd21e8b604. The problem was not with the signer algorithm, and the blank `:sha` algo works, despite being unclear in the docs. 