### PR TITLE
allow for checking string keys on the config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_twilio,
   account_sid: {:system, "TWILIO_ACCOUNT_SID"},

--- a/lib/ex_twilio/api.ex
+++ b/lib/ex_twilio/api.ex
@@ -146,9 +146,9 @@ defmodule ExTwilio.Api do
   """
   @spec auth_header(options :: list) :: list
   def auth_header(options \\ []) do
-    config = options[:config] || Config.new()
-    account = options[:account] || config.account
-    token = options[:token] || config.token
+    config = options[:config] || options["config"] || Config.new()
+    account = options[:account] || options["account"] || config.account
+    token = options[:token] || options["token"] || config.token
 
     auth_header([], {account, token})
   end


### PR DESCRIPTION
If the config object is passed to Oban, the keys will come back stringified and the auth header will fail to fetch the credentials. This adds an extra check before the fallback to `Config.new()`. 
Also updates config to use `import Config`.