### PR TITLE
Fix: fix 'use Bitwise is deprecated. import Bitwise instead' warning

### DIFF
--- a/lib/ex_twilio/request_validator.ex
+++ b/lib/ex_twilio/request_validator.ex
@@ -5,7 +5,7 @@ defmodule ExTwilio.RequestValidator do
   - [Twilio docs](https://www.twilio.com/docs/usage/security)
   """
 
-  use Bitwise
+  import Bitwise
 
   def valid?(url, params, signature, auth_token) do
     url


### PR DESCRIPTION
Fixes this compile warning:
![Screenshot on 2025-02-03 at 11-56-22](https://github.com/user-attachments/assets/50573c82-4ddc-4ff4-bca7-34eef6ae4e52)
